### PR TITLE
アップロード時の反応変更

### DIFF
--- a/frontend/src/components/Input.vue
+++ b/frontend/src/components/Input.vue
@@ -12,7 +12,6 @@
         :class="{ enter: isEnter }"
       >
         ファイルアップロード
-        <!-- <div> -->
 
         <input type="file" accept="image/*" @change="onImageChange" multiple />
       </div>
@@ -40,11 +39,10 @@
 
     <br />
     <div v-show="files.length">
-      <button class="button" v-on:click="upload">送信</button>
+      <button class="button" v-on:click="upload" v-bind:disabled="isPushed">
+        {{ button_message }}
+      </button>
     </div>
-
-    <p>{{ message }}</p>
-    <p>{{ error }}</p>
   </div>
 </template>
 
@@ -55,18 +53,23 @@ export default {
   name: "Input",
   data() {
     return {
-      message: "",
       error: "",
       isEnter: false,
       files: [],
       images: [],
       test: "",
+      isPushed: false,
+      button_message: "送信",
     };
   },
   methods: {
     // setError (error, text) {
     //   this.error = (error.response && error.response.data && error.response.data.error) || text
     // },
+    changeButton() {
+      this.isPushed = true;
+      this.button_message = "送信中";
+    },
     dragEnter() {
       this.isEnter = true;
     },
@@ -80,20 +83,23 @@ export default {
 
     checkGPS(files) {
       return new Promise((resolve) => {
-        files.forEach(file => {
+        files.forEach((file) => {
           loadImage.parseMetaData(file, (data) => {
-
-            if (data.exif && data.exif.get('GPSInfo')) {
+            if (data.exif && data.exif.get("GPSInfo")) {
               // console.log("fileWithGPS ", fileWithGPS);
               // console.log("3: GPS取得できてる");
               this.processFile(file);
             } else {
-              alert("エラー: " + file.name + "\n位置情報を含む画像を選択してください");
+              alert(
+                "エラー: " +
+                  file.name +
+                  "\n位置情報を含む画像を選択してください"
+              );
             }
           });
-        })
+        });
         resolve();
-      })
+      });
     },
 
     processFile(file) {
@@ -107,7 +113,7 @@ export default {
         // console.log(base64EncodedFile); // base64にしたデータ
         this.images.push(base64EncodedFile);
         this.files.push(file);
-      }
+      };
     },
 
     dropFile() {
@@ -122,6 +128,7 @@ export default {
     },
 
     upload: function () {
+      this.changeButton();
       var resStatus;
       var getRequest;
 
@@ -142,7 +149,6 @@ export default {
           resStatus = response.status;
           getRequest = response.data.trip_id;
           // console.log(getRequest);
-          this.message = "アップロードしました";
           this.error = "";
           if (resStatus == 200) {
             // console.log(this.$store.state.tripid);

--- a/frontend/src/components/Input.vue
+++ b/frontend/src/components/Input.vue
@@ -40,7 +40,7 @@
     <br />
     <div v-show="files.length">
       <button class="button" v-on:click="upload" v-bind:disabled="isPushed">
-        {{ button_message }}
+        {{ button_text }}
       </button>
     </div>
   </div>
@@ -59,7 +59,7 @@ export default {
       images: [],
       test: "",
       isPushed: false,
-      button_message: "送信",
+      button_text: "送信",
     };
   },
   methods: {
@@ -68,7 +68,7 @@ export default {
     // },
     changeButton() {
       this.isPushed = true;
-      this.button_message = "送信中";
+      this.button_text = "送信中";
     },
     dragEnter() {
       this.isEnter = true;

--- a/frontend/src/components/MyMap.vue
+++ b/frontend/src/components/MyMap.vue
@@ -2,7 +2,7 @@
   <div class="Map">
     <div id="map"></div>
     <div class="overlay">
-       <button id="replay">Replay</button>
+      <button id="replay">Replay</button>
     </div>
   </div>
 </template>
@@ -88,17 +88,17 @@ export default {
       });
 
       var point = {
-        'type': 'FeatureCollection',
-        'features': [
+        type: "FeatureCollection",
+        features: [
           {
-            'type': 'Feature',
-            'properties': {},
-            'geometry': {
-              'type': 'Point',
-              'coordinates': route[0]
-            }
-          }
-        ]
+            type: "Feature",
+            properties: {},
+            geometry: {
+              type: "Point",
+              coordinates: route[0],
+            },
+          },
+        ],
       };
 
       var counter = 0;
@@ -118,7 +118,7 @@ export default {
         });
         map.addSource("point", {
           type: "geojson",
-          data: point
+          data: point,
         });
         map.addLayer({
           id: "route",
@@ -134,32 +134,25 @@ export default {
           },
         });
         map.addLayer({
-          'id': 'point',
-          'source': 'point',
-          'type': 'symbol',
-          'layout': {
-            'icon-image': 'car-15',
-            'icon-rotate': ['get', 'bearing'],
-            'icon-rotation-alignment': 'map',
-            'icon-allow-overlap': true,
-            'icon-ignore-placement': true,
-            'icon-size': 2.5
-          }
+          id: "point",
+          source: "point",
+          type: "symbol",
+          layout: {
+            "icon-image": "car-15",
+            "icon-rotate": ["get", "bearing"],
+            "icon-rotation-alignment": "map",
+            "icon-allow-overlap": true,
+            "icon-ignore-placement": true,
+            "icon-size": 2.5,
+          },
         });
         function animate() {
-          var start =
-            route[
-              counter >= steps ? counter - 1 : counter
-            ];
-          var end =
-            route[
-              counter >= steps ? counter : counter + 1
-            ];
+          var start = route[counter >= steps ? counter - 1 : counter];
+          var end = route[counter >= steps ? counter : counter + 1];
           if (!start || !end) return;
-          
-          point.features[0].geometry.coordinates =
-          route[counter];
-          
+
+          point.features[0].geometry.coordinates = route[counter];
+
           // Calculate the bearing to ensure the icon is rotated to match the route arc
           // The bearing is calculated between the current point and the next point, except
           // at the end of the arc, which uses the previous point and the current point
@@ -167,34 +160,33 @@ export default {
           //   turf.point(start),
           //   turf.point(end)
           // );
-          
-          map.getSource('point').setData(point);
-          
+
+          map.getSource("point").setData(point);
+
           if (counter < steps) {
             requestAnimationFrame(animate);
           }
-          
+
           counter = counter + 1;
         }
         document
-          .getElementById('replay')
-          .addEventListener('click', function () {
+          .getElementById("replay")
+          .addEventListener("click", function () {
             // Set the coordinates of the original point back to origin
             point.features[0].geometry.coordinates = origin;
-            
+
             // Update the source layer
-            map.getSource('point').setData(point);
-            
+            map.getSource("point").setData(point);
+
             // Reset the counter
             counter = 0;
-            
+
             // Restart the animation
             animate(counter);
           });
- 
+
         animate(counter);
       });
-
 
       map.on("mouseenter", "places", function () {
         map.getCanvas().style.cursor = "pointer";
@@ -219,9 +211,9 @@ export default {
         }).setDOMContent(pop);
 
         new mapboxgl.Marker({
-            element: el,
-            anchor: 'bottom'
-          })
+          element: el,
+          anchor: "bottom",
+        })
           .setLngLat(marker.geometry.coordinates)
           .setPopup(popup)
           .addTo(map);
@@ -251,7 +243,7 @@ export default {
   left: 30px;
 }
 .overlay button {
-  font: 600 12px/20px 'Helvetica Neue', Arial, Helvetica, sans-serif;
+  font: 600 12px/20px "Helvetica Neue", Arial, Helvetica, sans-serif;
   background-color: #3386c0;
   color: #fff;
   display: inline-block;
@@ -261,7 +253,7 @@ export default {
   cursor: pointer;
   border-radius: 3px;
 }
- 
+
 .overlay button:hover {
   background-color: #4ea0da;
 }


### PR DESCRIPTION
### 概要
アップロードの動作がユーザに伝わるようにする

### 変更内容
アップロード時にボタンが「送信」から「送信中」となりボタン機能がオフになるように変更

### 動作確認
送信前
<img width="852" alt="スクリーンショット 2021-09-11 17 24 27" src="https://user-images.githubusercontent.com/32430191/132941658-fb841851-f9ec-46aa-80c2-ac611b070105.png">

送信後
<img width="846" alt="スクリーンショット 2021-09-11 17 24 33" src="https://user-images.githubusercontent.com/32430191/132941663-f3c87cc3-6457-4aa5-a136-0e4cfa4c3022.png">


### 備考(注記)
時間があればもっとリッチにする